### PR TITLE
Add a syscall stub library for non-Windows platforms.

### DIFF
--- a/syscall_stub.go
+++ b/syscall_stub.go
@@ -1,0 +1,48 @@
+//go:build !windows
+// +build !windows
+
+package comutil
+
+import (
+	"errors"
+	"unsafe"
+
+	"github.com/go-ole/go-ole"
+	"github.com/google/uuid"
+)
+
+var (
+	ErrUnsupported = errors.New("call is unsupported on this platform")
+)
+
+func CreateInstanceEx(clsid uuid.UUID, context uint, serverInfo *CoServerInfo, results []MultiQI) (err error) {
+	return ErrUnsupported
+}
+
+func IIDFromString(value string) (iid *ole.GUID, err error) {
+	return nil, ErrUnsupported
+}
+
+func SafeArrayCopy(original *ole.SafeArray) (duplicate *ole.SafeArray, err error) {
+	return nil, ErrUnsupported
+}
+
+func SafeArrayCreateVector(variantType ole.VT, lowerBound int32, length uint32) (safearray *ole.SafeArray, err error) {
+	return nil, ErrUnsupported
+}
+
+func SafeArrayGetElement(safearray *ole.SafeArray, index int32, element unsafe.Pointer) (err error) {
+	return ErrUnsupported
+}
+
+func SafeArrayPutElement(safearray *ole.SafeArray, index int32, element unsafe.Pointer) (err error) {
+	return ErrUnsupported
+}
+
+func SafeArrayGetDim(safearray *ole.SafeArray) (dimensions uint32, err error) {
+	return 0, ErrUnsupported
+}
+
+func BuildVarArrayStr(elements ...string) (v *ole.VARIANT, err error) {
+	return nil, ErrUnsupported
+}

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -1,3 +1,6 @@
+//go:build windows
+// +build windows
+
 package comutil
 
 import (


### PR DESCRIPTION
comutil causes problems when used as a dependency of cross-platform packages due to syscall.go not being tagged as Windows-specific. comutil's own dependencies (eg syscall.LoadDLL) will be missing on non-Windows platforms leading to build failures.

Tag syscall (as implemented) as +build windows, and create a stub library for +build !windows. The stub library lacks any meaningful functionality, but provides the necessary function signatures to make the Go compiler happy.